### PR TITLE
Support custom error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-module.exports = function (f, t) {
+module.exports = function (f, t, e) {
     if (!t)
         return f
-    var err = new Error('timeout of '+t+'ms exceeded for callback ' + (f.name||'anonymous'))
+    var err = new Error(e || 'timeout of '+t+'ms exceeded for callback ' + (f.name||'anonymous'))
     err.name = 'Timeout'
     var ecb = function () {
         clearTimeout(timer)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "version": "0.1.0",
     "description": "Invokes callback with single error argument if timeout occurs before it's invoked by other means",
     "main": "index.js",
+    "scripts": {
+        "test": "tape test/**/*.js"
+    },
     "directories": {
         "example": "example",
         "test": "test"
@@ -17,7 +20,7 @@
         "timeout"
     ],
     "devDependencies" : {
-        "tape" : "~0.1.5"
+        "tape" : "~4.0.0"
     },
     "testling" : {
         "files" : "test/*.js",

--- a/test/error-message.js
+++ b/test/error-message.js
@@ -1,0 +1,26 @@
+var test    = require('tape')
+,   timeout = require('..')
+
+test(function (t) {
+    t.plan(3)
+
+    function doSomethingFast(cb) { setTimeout(cb, 50) }
+    function doSomethingSlow(cb) { setTimeout(cb, 500) }
+
+    doSomethingFast(timeout(function doSomethingFastHandler (err) {
+        if (err)
+            t.fail('doSomethingFastHandler got an error')
+        else
+            t.pass('doSomethingFastHandler did not get an error')
+    }, 1000, 'fast function timed out'))
+
+    doSomethingSlow(timeout(function doSomethingSlowHandler (err) {
+        if (err) {
+            t.pass('doSomethingSlowHandler got error')
+            t.ok(err.message.indexOf('slow function timed out') >- 1, 'callback err had custom error message')
+        } else {
+            t.fail('doSomethingSlowHandler did not get an error')
+        }
+    }, 250, 'slow function timed out'))
+})
+


### PR DESCRIPTION
This PR adds support for custom error messages on timeout.

I also took the opportunity to add an `npm test` script and upgrade tape (so the executable is available).