### PR TITLE
Update: Timeout a Callback Without Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var timeout      = require('callback-timeout'),
 
 ### timeout(callback [, ms, msg])
 
-Returns a callback function that will execute after `ms` milliseconds with a single `TimeoutError` argument if not invoked by other means first. If the `ms` timeout argument is omitted, 0, or null, then the timeout is disabled and the original callback is returned. `msg` may be used to set a custom error message (on timeout), otherwise an appropriate one will be set for you.
+Returns a callback function that will execute after `ms` milliseconds with a single `TimeoutError` argument if not invoked by other means first. If the `ms` timeout argument is omitted, 0, or null, then the timeout is disabled and the original callback is returned. `msg` may be used to set a custom error message (on timeout), otherwise an appropriate one will be set for you. If `false` is set for the timeout message the callback is returned without an error (null, on timeout).
 
 ### TimeoutError
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ module.exports = function callbackTimeout (f, t, e) {
 
   function onTimeout () {
     timer = null
+    if (e === false)
+      return f.call(f, null)
     var msg = e || 'timeout of ' +
       t + 'ms exceeded for callback ' +
       (f.name || 'anonymous')


### PR DESCRIPTION
Useful if the response is not required e.g. a cache service not returning a cached result, especially when used with `async` control flows.